### PR TITLE
[RCA-38] When sending a service invocation, service object is copied …

### DIFF
--- a/src/main/java/com/jaguarlandrover/rvi/DlinkReceivePacket.java
+++ b/src/main/java/com/jaguarlandrover/rvi/DlinkReceivePacket.java
@@ -59,11 +59,7 @@ class DlinkReceivePacket extends DlinkPacket
         super(Command.RECEIVE);
 
         mMod = "proto_json_rpc";
-        mService = service;
-
-
-        // TODO: With this paradigm, if one of the parameters of mService changes, mData string will still be the same.
-        //mData = mService.jsonString();//Base64.encodeToString(mService.jsonString().getBytes(), Base64.DEFAULT);
+        mService = service.copy();
     }
 
 //    public DlinkReceivePacket(HashMap jsonHash) {

--- a/src/main/java/com/jaguarlandrover/rvi/Service.java
+++ b/src/main/java/com/jaguarlandrover/rvi/Service.java
@@ -135,6 +135,10 @@ class Service
         return mNodeIdentifier != null;
     }
 
+    private String getNodeIdentifier() {
+        return mNodeIdentifier;
+    }
+
     /**
      * Sets the node identifier portion of the fully-qualified service name
      *
@@ -218,5 +222,14 @@ class Service
      */
     void setTimeout(Long timeout) {
         mTimeout = timeout;
+    }
+
+    public Service copy() {
+        Service copy = new Service(this.getServiceIdentifier(), this.getDomain(), this.getBundleIdentifier(), this.getNodeIdentifier());
+
+        copy.setTimeout(this.getTimeout());
+        copy.setParameters(this.getParameters());
+
+        return null;
     }
 }


### PR DESCRIPTION
…into dlink packet so subsequent invocations don't overwrite the parameters.

(cherry picked from commit 3c8e5db8ce3825d43470eb58513c1969536fe7c2)
