### PR TITLE
[RCA-39] Made it so that queued pending service invocations all go ou…

### DIFF
--- a/src/main/java/com/jaguarlandrover/rvi/BluetoothConnection.java
+++ b/src/main/java/com/jaguarlandrover/rvi/BluetoothConnection.java
@@ -54,7 +54,7 @@ class BluetoothConnection implements RemoteConnectionInterface
         if (!isConnected() || !isConfigured()) // TODO: Call error on listener
             return;
 
-        new SendDataTask(dlinkPacket).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);//, dlinkPacket.toJsonString());
+        new SendDataTask(dlinkPacket).executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);//, dlinkPacket.toJsonString());
     }
 
     @Override
@@ -97,7 +97,7 @@ class BluetoothConnection implements RemoteConnectionInterface
         Log.d(TAG, "Connecting to device: " + mDeviceAddress + ":" + mServiceRecord + ":" + mChannel);
 
         ConnectTask connectAndAuthorizeTask = new ConnectTask(mDeviceAddress, mServiceRecord, mChannel);
-        connectAndAuthorizeTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        connectAndAuthorizeTask.executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);
     }
 
     private class ConnectTask extends AsyncTask<Void, String, Throwable>
@@ -186,7 +186,7 @@ class BluetoothConnection implements RemoteConnectionInterface
                 Log.d(TAG, "Connecting Bluetooth socket: Creating listener...");
 
                 ListenTask listenTask = new ListenTask();
-                listenTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+                listenTask.executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);
 
                 if (mRemoteConnectionListener != null)
                     mRemoteConnectionListener.onRemoteConnectionDidConnect();

--- a/src/main/java/com/jaguarlandrover/rvi/ServerConnection.java
+++ b/src/main/java/com/jaguarlandrover/rvi/ServerConnection.java
@@ -49,7 +49,7 @@ class ServerConnection implements RemoteConnectionInterface
             return;
         }
 
-        new SendDataTask(dlinkPacket).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);//, dlinkPacket.toJsonString());
+        new SendDataTask(dlinkPacket).executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);//, dlinkPacket.toJsonString());
     }
 
     @Override
@@ -93,7 +93,7 @@ class ServerConnection implements RemoteConnectionInterface
         Log.d(TAG, "Connecting the socket: " + mServerUrl + ":" + mServerPort);
 
         ConnectTask connectAndAuthorizeTask = new ConnectTask(mServerUrl, mServerPort, mServerKeyStore, mClientKeyStore, mClientKeyStorePassword);
-        connectAndAuthorizeTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        connectAndAuthorizeTask.executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);
     }
 
     private class ConnectTask extends AsyncTask<Void, String, Throwable>
@@ -200,7 +200,7 @@ class ServerConnection implements RemoteConnectionInterface
             if (result == null) {
                 // TODO: Does the input buffer stream cache data in the case that my async thread sends the auth command before the listener is set up?
                 ListenTask listenTask = new ListenTask();
-                listenTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+                listenTask.executeOnExecutor(AsyncTask.SERIAL_EXECUTOR);
 
                 if (mRemoteConnectionListener != null)
                     mRemoteConnectionListener.onRemoteConnectionDidConnect();


### PR DESCRIPTION
…t all at once, as opposed to only sending the last-invoked invocation, in the order they were received. Changed all the network-related background thread execution to be serial to guarantee order stays correct. Not really tested though.

(cherry picked from commit 993b0592d4bc10e6faf1245e8fed680d999899ff)
